### PR TITLE
fix: update installer and dir

### DIFF
--- a/com.tdameritrade.ThinkOrSwim.yaml
+++ b/com.tdameritrade.ThinkOrSwim.yaml
@@ -1,3 +1,4 @@
+---
 app-id: com.tdameritrade.ThinkOrSwim
 runtime: org.freedesktop.Platform
 runtime-version: '23.08'
@@ -9,10 +10,11 @@ tags:
   - proprietary
 
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk11
+  - org.freedesktop.Sdk.Extension.openjdk17
 
 finish-args:
   - --persist=.thinkorswim
+  - --persist=thinkorswim
   - --socket=x11
   - --share=ipc
   - --socket=pulseaudio
@@ -25,24 +27,30 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk11/install.sh
+      - /usr/lib/sdk/openjdk17/install.sh
 
   - name: thinkorswim
     buildsystem: simple
 
     build-commands:
       - install -D thinkorswim /app/bin/thinkorswim
-      - install -Dm644 -t /app/share/metainfo com.tdameritrade.ThinkOrSwim.metainfo.xml
-      - install -Dm644 -t /app/share/applications com.tdameritrade.ThinkOrSwim.desktop
-      - install -Dm644 -t /app/share/icons/hicolor/512x512/apps com.tdameritrade.ThinkOrSwim.png
+      - >-
+        install -Dm644 -t
+        /app/share/metainfo com.tdameritrade.ThinkOrSwim.metainfo.xml
+      - >-
+        install -Dm644 -t
+        /app/share/applications com.tdameritrade.ThinkOrSwim.desktop
+      - >-
+        install -Dm644 -t
+        /app/share/icons/hicolor/512x512/apps com.tdameritrade.ThinkOrSwim.png
 
     sources:
       - type: extra-data
         filename: thinkorswim_installer.sh
         url: >-
-          https://mediaserver.thinkorswim.com/installer/InstFiles/thinkorswim_installer.sh
-        sha256: 97bb132c93572e0568d34b6a935bd7826c2bf3588cb3044b65c5947d6d2b4daf
-        size: 17744410
+          https://tosmediaserver.schwab.com/installer/InstFiles/thinkorswim_installer.sh
+        sha256: ddfb04af2ae3cb5d5afc984d8ec4c37ad02a6fefdab167497729b5c70301fc52
+        size: 18286803
 
       - type: file
         path: thinkorswim

--- a/thinkorswim
+++ b/thinkorswim
@@ -1,15 +1,8 @@
 #!/bin/sh
 
-DIR=${XDG_DATA_HOME}/thinkorswim
-
-if [ ! -f "${DIR}/thinkorswim" ]; then
-    sh /app/extra/thinkorswim_installer.sh -q -dir "${DIR}"
+if [ ! -f "${HOME}/thinkorswim/thinkorswim" ]; then
+    echo "Installing thinkorswim..."
+    sh /app/extra/thinkorswim_installer.sh -q
 fi
 
-# NOTE(jkoelker) I don't know why, but removing `ACCOUNT_MODELS` fixes the
-#                wayland window rehoming issue (main window doesn't show).
-for workspace in "${DIR}"/workspace.*.tos.prod.xml; do
-    sed -i 's/WORKSPACE ACCOUNT_MODELS=[^ ]*/WORKSPACE/' "${workspace}"
-done
-
-exec "${DIR}/thinkorswim" "$@"
+exec "${HOME}/thinkorswim/thinkorswim" "$@"


### PR DESCRIPTION
Schwab has updated the installer, and is now hosting it at their own media url. It now requires java 17, so update the sdk. The `-dir` argument to install to a custom location seems broken, so remove it and just persist the `thinkorswim` dir it creates in the sandbox's home.

Fixes: #3
Fixes: #9 